### PR TITLE
feat(auth-secure-ui): interceptor JWT + signOut 401/403 + UI Login/Register/Home 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-navigation/native": "^7.1.17",
         "@react-navigation/native-stack": "^7.3.26",
+        "axios": "^1.12.2",
         "expo": "~54.0.10",
         "expo-location": "~19.0.7",
         "expo-secure-store": "~15.0.7",
@@ -4204,6 +4205,23 @@
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
       "license": "MIT"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/babel-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
@@ -4645,6 +4663,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/caller-callsite": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
@@ -4980,6 +5011,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
@@ -5226,6 +5269,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -5279,6 +5331,20 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/eastasianwidth": {
@@ -5339,6 +5405,51 @@
       "license": "MIT",
       "dependencies": {
         "stackframe": "^1.3.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/escalade": {
@@ -6207,6 +6318,26 @@
       "integrity": "sha512-3PYnM29RFXwvAN6Pc/scUfkI7RwhQ/xqyLUyPNlXUp9S40zI8nup9tUSrTLSVnWGBN38FNiGWbwZOB6uR4OGdw==",
       "license": "MIT"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fontfaceobserver": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/fontfaceobserver/-/fontfaceobserver-2.3.0.tgz",
@@ -6227,6 +6358,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/freeport-async": {
@@ -6294,6 +6441,30 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -6301,6 +6472,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/getenv": {
@@ -6344,6 +6528,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -6357,6 +6553,33 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/hasown": {
@@ -7552,6 +7775,15 @@
       "integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==",
       "license": "Apache-2.0"
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/memoize-one": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
@@ -8610,6 +8842,12 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-navigation/native": "^7.1.17",
     "@react-navigation/native-stack": "^7.3.26",
+    "axios": "^1.12.2",
     "expo": "~54.0.10",
     "expo-location": "~19.0.7",
     "expo-secure-store": "~15.0.7",

--- a/src/components/AuthGate.tsx
+++ b/src/components/AuthGate.tsx
@@ -1,0 +1,18 @@
+import React, { useEffect, useState } from 'react';
+import { Text } from 'react-native';
+import { onAuthStateChanged } from 'firebase/auth';
+import { auth } from '../lib/firebase';
+
+export default function AuthGate({ children }: { children: React.ReactNode }) {
+    const [ready, setReady] = useState(false);
+    const [authed, setAuthed] = useState<boolean | null>(null);
+
+    useEffect(() => onAuthStateChanged(auth, (u) => {
+        setAuthed(!!u);
+        setReady(true);
+    }), []);
+
+    if (!ready) return <Text>Cargando…</Text>;
+    if (!authed) return <Text>Sesión expirada o no iniciada</Text>;
+    return <>{children}</>;
+}

--- a/src/components/ui/AppButton.tsx
+++ b/src/components/ui/AppButton.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { Pressable, Text, StyleSheet, ViewStyle } from 'react-native';
+import { colors, radius, shadow } from '../../theme';
+
+type Props = {
+    title: string;
+    onPress: () => void;
+    disabled?: boolean;
+    variant?: 'primary' | 'secondary' | 'danger';
+    fullWidth?: boolean;
+    style?: ViewStyle;
+};
+
+export default function AppButton({
+    title,
+    onPress,
+    disabled,
+    variant = 'primary',
+    fullWidth = true,
+    style,
+}: Props) {
+    const bg =
+        variant === 'danger' ? colors.danger :
+            variant === 'secondary' ? colors.border :
+                colors.primary;
+
+    const textColor = variant === 'secondary' ? colors.text : '#fff';
+
+    return (
+        <Pressable
+            onPress={onPress}
+            disabled={disabled}
+            android_ripple={{ color: '#00000022' }}
+            style={({ pressed }) => [
+                styles.btn,
+                { backgroundColor: bg, opacity: disabled || pressed ? 0.9 : 1, width: fullWidth ? '100%' : undefined },
+                shadow,
+                style,
+            ]}
+        >
+            <Text style={[styles.label, { color: textColor }]} numberOfLines={1}>
+                {title}
+            </Text>
+        </Pressable>
+    );
+}
+
+const styles = StyleSheet.create({
+    btn: {
+        paddingVertical: 14,
+        paddingHorizontal: 16,
+        borderRadius: radius,
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    label: {
+        fontSize: 16,
+        fontWeight: '600',
+        letterSpacing: 0.3,
+    },
+});

--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -1,38 +1,66 @@
+import React, { useEffect, useState } from 'react';
+import { ActivityIndicator, View, Text } from 'react-native';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import type { User } from 'firebase/auth';
+
 import LoginScreen from '../screens/LoginScreen';
 import RegisterScreen from '../screens/RegisterScreen';
 import HomeScreen from '../screens/HomeScreen';
 import MapScreen from '../screens/MapScreen';
 import { listenAuth } from '../services/auth';
-import { useEffect, useState } from 'react';
-import { User } from 'firebase/auth';
 
-const Stack = createNativeStackNavigator();
+const AppStack = createNativeStackNavigator();
+const AuthStack = createNativeStackNavigator();
+
+function Loading() {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', gap: 8 }}>
+      <ActivityIndicator />
+      <Text>Cargando…</Text>
+    </View>
+  );
+}
+
+function AppNavigator() {
+  return (
+    <AppStack.Navigator>
+      <AppStack.Screen name="Home" component={HomeScreen} />
+      <AppStack.Screen name="Map" component={MapScreen} />
+    </AppStack.Navigator>
+  );
+}
+
+function AuthNavigator() {
+  return (
+    <AuthStack.Navigator>
+      <AuthStack.Screen name="Login" component={LoginScreen} />
+      <AuthStack.Screen name="Register" component={RegisterScreen} />
+    </AuthStack.Navigator>
+  );
+}
 
 export default function RootNavigator() {
-    const [user, setUser] = useState<User | null>(null);
-    const [loading, setLoading] = useState(true);
+  const [user, setUser] = useState<User | null>(null);
+  const [ready, setReady] = useState(false);
 
-    useEffect(() => listenAuth(u => { setUser(u); setLoading(false); }), []);
+  useEffect(() => {
+    let settled = false;
+    const unsub = listenAuth((u) => {
+      console.log('[RootNavigator] auth changed →', !!u);
+      setUser(u);
+      if (!settled) { setReady(true); settled = true; }
+    });
+    const t = setTimeout(() => { if (!settled) { setReady(true); settled = true; } }, 2000);
+    return () => { clearTimeout(t); unsub(); };
+  }, []);
 
-    if (loading) return null;
+  if (!ready) return <Loading />;
 
-    return (
-        <NavigationContainer>
-            <Stack.Navigator>
-                {user ? (
-                    <>
-                        <Stack.Screen name="Home" component={HomeScreen} />
-                        <Stack.Screen name="Map" component={MapScreen} />
-                    </>
-                ) : (
-                    <>
-                        <Stack.Screen name="Login" component={LoginScreen} />
-                        <Stack.Screen name="Register" component={RegisterScreen} />
-                    </>
-                )}
-            </Stack.Navigator>
-        </NavigationContainer>
-    );
+  return (
+    <NavigationContainer>
+      {/* key fuerza el remount completo del árbol */}
+      {user ? <AppNavigator key="app" /> : <AuthNavigator key="auth" />}
+    </NavigationContainer>
+  );
 }

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,39 +1,96 @@
-import { useState } from 'react';
-import { View, Text, Button } from 'react-native';
+import React, { useState } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import AppButton from '../components/ui/AppButton';
 import { logout } from '../services/auth';
 import { clearToken } from '../storage/secure';
 import WeatherCard from '../components/WeatherCard';
+import { httpSecure } from '../services/http.secure';
+import { colors, radius, shadow } from '../theme';
+
+const SHOW_TEST_BUTTONS = (process.env.EXPO_PUBLIC_SHOW_TEST_BUTTONS === '1');
 
 export default function HomeScreen({ navigation }: any) {
-    const [showWeather, setShowWeather] = useState(false);
+  const [showWeather, setShowWeather] = useState(false);
+  const [busy, setBusy] = useState(false);
 
-    return (
-        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', gap: 12 }}>
-            <Text>Usuario autenticado ✅</Text>
+  const testAuthHeader = async () => {
+    try {
+      setBusy(true);
+      const { data } = await httpSecure.get('https://httpbin.org/anything');
+      const h = data?.headers?.Authorization || data?.headers?.authorization;
+      alert(h?.startsWith('Bearer ') ? 'OK: llegó Authorization' : 'Falta header Authorization');
+    } finally { setBusy(false); }
+  };
 
-            {/* Botón para mostrar/ocultar clima */}
-            <Button
-                title={showWeather ? "Ocultar clima" : "Verificar clima"}
-                onPress={() => setShowWeather((prev) => !prev)}
-            />
+  const test401 = async () => {
+    try {
+      setBusy(true);
+      await httpSecure.get('https://httpbin.org/status/401');
+    } catch { /* interceptor hará signOut */ }
+    finally { setBusy(false); }
+  };
 
-            {/* Tarjeta del clima */}
-            {showWeather && <WeatherCard />}
+  return (
+    <View style={{ flex: 1, backgroundColor: colors.bg }}>
+      <View style={styles.header}>
+        <Text style={styles.headerTitle}>Bienvenido</Text>
+      </View>
 
-            {/* Botón para abrir mapa */}
-            <Button
-                title="Abrir mapa"
-                onPress={() => navigation.navigate('Map')}
-            />
+      <View style={styles.body}>
+        <View style={[styles.card, shadow]}>
 
-            <Button
-                title="Cerrar sesión"
-                color="red"
-                onPress={async () => {
-                    await logout();
-                    await clearToken();
-                }}
-            />
+          {SHOW_TEST_BUTTONS && (
+            <>
+              <AppButton
+                title={busy ? 'Probando…' : 'Probar envío de Authorization'}
+                onPress={testAuthHeader}
+                disabled={busy}
+              />
+              <AppButton
+                title={busy ? 'Probando…' : 'Probar 401 (debe cerrar sesión)'}
+                variant="danger"
+                onPress={test401}
+                disabled={busy}
+              />
+            </>
+          )}
+
+          <AppButton
+            title={showWeather ? 'Ocultar clima' : 'Verificar clima'}
+            variant="secondary"
+            onPress={() => setShowWeather((p) => !p)}
+          />
+          {showWeather && <WeatherCard />}
+
+          <AppButton title="Abrir mapa" onPress={() => navigation.navigate('Map')} />
+          <AppButton title="Cerrar sesión" variant="danger" onPress={async () => {
+            await logout();
+            await clearToken();
+          }} />
         </View>
-    );
+      </View>
+    </View>
+  );
 }
+
+const styles = StyleSheet.create({
+  header: {
+    height: 56,
+    justifyContent: 'center',
+    paddingHorizontal: 16,
+    backgroundColor: colors.card,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  headerTitle: { fontSize: 18, fontWeight: '700', color: colors.text },
+  body: { flex: 1, padding: 16, alignItems: 'center', justifyContent: 'flex-start' },
+  card: {
+    width: '100%',
+    maxWidth: 520,
+    backgroundColor: colors.card,
+    borderRadius: radius,
+    padding: 16,
+    gap: 10,
+  },
+  title: { fontSize: 18, fontWeight: '600', color: colors.text },
+});

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -1,28 +1,88 @@
-import { useState } from 'react';
-import { View, TextInput, Button, Alert } from 'react-native';
+import React, { useState } from 'react';
+import { View, Text, TextInput, StyleSheet, Alert, KeyboardAvoidingView, Platform } from 'react-native';
 import { login } from '../services/auth';
 import { saveToken } from '../storage/secure';
-import { auth } from '../services/firebase';
+import { auth } from '../lib/firebase';
+import { colors, radius, shadow } from '../theme';
+import AppButton from '../components/ui/AppButton';
 
 export default function LoginScreen({ navigation }: any) {
-    const [email, setEmail] = useState(''); const [password, setPassword] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [busy, setBusy] = useState(false);
 
-    const onLogin = async () => {
-        try {
-            await login(email, password);
-            const idToken = await auth.currentUser?.getIdToken();
-            if (idToken) await saveToken(idToken);
-        } catch (e: any) {
-            Alert.alert('Error', e.message);
-        }
-    };
+  const onLogin = async () => {
+    try {
+      setBusy(true);
+      await login(email.trim(), password);
+      const idToken = await auth.currentUser?.getIdToken(true);
+      if (idToken) await saveToken(idToken);
+      // RootNavigator cambiará al stack autenticado
+    } catch (e: any) {
+      Alert.alert('Error', e?.message ?? 'No se pudo iniciar sesión');
+    } finally {
+      setBusy(false);
+    }
+  };
 
-    return (
-        <View style={{ padding: 16, gap: 8 }}>
-            <TextInput placeholder="Email" autoCapitalize="none" onChangeText={setEmail} value={email} />
-            <TextInput placeholder="Password" secureTextEntry onChangeText={setPassword} value={password} />
-            <Button title="Entrar" onPress={onLogin} />
-            <Button title="Crear cuenta" onPress={() => navigation.navigate('Register')} />
+  return (
+    <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : undefined} style={{ flex: 1, backgroundColor: colors.bg }}>
+      <View style={styles.container}>
+        <View style={[styles.card, shadow]}>
+          <Text style={styles.title}>Ingresa</Text>
+          <Text style={styles.subtitle}>Usa tu correo y contraseña</Text>
+
+          <TextInput
+            placeholder="Correo"
+            placeholderTextColor={colors.muted}
+            autoCapitalize="none"
+            keyboardType="email-address"
+            value={email}
+            onChangeText={setEmail}
+            style={styles.input}
+          />
+          <TextInput
+            placeholder="Contraseña"
+            placeholderTextColor={colors.muted}
+            secureTextEntry
+            value={password}
+            onChangeText={setPassword}
+            style={styles.input}
+          />
+
+          <AppButton title={busy ? 'Entrando…' : 'Entrar'} onPress={onLogin} disabled={busy} />
+          <AppButton
+            title="Crear cuenta"
+            variant="secondary"
+            onPress={() => navigation.navigate('Register')}
+            style={{ marginTop: 10 }}
+          />
         </View>
-    );
+      </View>
+    </KeyboardAvoidingView>
+  );
 }
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 20 },
+  card: {
+    width: '100%',
+    maxWidth: 420,
+    backgroundColor: colors.card,
+    borderRadius: radius,
+    padding: 20,
+    gap: 12,
+  },
+  title: { fontSize: 22, fontWeight: '700', color: colors.text },
+  subtitle: { color: colors.muted, marginBottom: 4 },
+  input: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radius,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    fontSize: 16,
+    color: colors.text,
+    backgroundColor: '#fff',
+  },
+});

--- a/src/screens/RegisterScreen.tsx
+++ b/src/screens/RegisterScreen.tsx
@@ -1,36 +1,116 @@
-import { useState } from 'react';
-import { View, TextInput, Button, Alert } from 'react-native';
+// src/screens/RegisterScreen.tsx
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  StyleSheet,
+  KeyboardAvoidingView,
+  Platform,
+  Alert,
+} from 'react-native';
 import { register } from '../services/auth';
 import { saveToken } from '../storage/secure';
+import AppButton from '../components/ui/AppButton';
+import { colors, radius, shadow } from '../theme';
 
 export default function RegisterScreen({ navigation }: any) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [busy, setBusy] = useState(false);
 
   const onRegister = async () => {
-    try {
-      const cred = await register(email.trim(), password);
-      const idToken = await cred.user.getIdToken();
-      if (idToken) await saveToken(idToken);
+    if (!email.trim() || !password) {
+      Alert.alert('Completa los campos', 'Correo y contraseña son obligatorios.');
+      return;
+    }
+    if (password.length < 6) {
+      Alert.alert('Contraseña débil', 'La contraseña debe tener al menos 6 caracteres.');
+      return;
+    }
 
-      // Si NO usas listenAuth en RootNavigator:
-      navigation.replace('Home'); 
-      // Si SÍ usas listenAuth, puedes omitir la línea de arriba.
+    try {
+      setBusy(true);
+      const user = await register(email.trim(), password); 
+      const idToken = await user.getIdToken(true);
+      if (idToken) await saveToken(idToken);
     } catch (e: any) {
       const msg =
-        e?.code === 'auth/email-already-in-use' ? 'Ese correo ya está en uso.'
-      : e?.code === 'auth/invalid-email'        ? 'Correo inválido.'
-      : e?.code === 'auth/weak-password'        ? 'La contraseña es muy débil.'
-      : e?.message || 'Error al registrarse.';
+        e?.code === 'auth/email-already-in-use' ? 'Ese correo ya está en uso.' :
+        e?.code === 'auth/invalid-email'        ? 'Correo inválido.' :
+        e?.code === 'auth/weak-password'        ? 'La contraseña es muy débil.' :
+        e?.message || 'No se pudo crear la cuenta.';
       Alert.alert('Error', msg);
+    } finally {
+      setBusy(false);
     }
   };
 
   return (
-    <View style={{ padding: 16, gap: 8 }}>
-      <TextInput placeholder="Email" autoCapitalize="none" onChangeText={setEmail} value={email} />
-      <TextInput placeholder="Password" secureTextEntry onChangeText={setPassword} value={password} />
-      <Button title="Crear cuenta" onPress={onRegister} />
-    </View>
+    <KeyboardAvoidingView
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      style={{ flex: 1, backgroundColor: colors.bg }}
+    >
+      <View style={styles.container}>
+        <View style={[styles.card, shadow]}>
+          <Text style={styles.title}>Crea tu cuenta</Text>
+          <Text style={styles.subtitle}>Regístrate con tu correo</Text>
+
+          <TextInput
+            style={styles.input}
+            placeholder="Correo"
+            placeholderTextColor={colors.muted}
+            autoCapitalize="none"
+            keyboardType="email-address"
+            value={email}
+            onChangeText={setEmail}
+          />
+          <TextInput
+            style={styles.input}
+            placeholder="Contraseña"
+            placeholderTextColor={colors.muted}
+            secureTextEntry
+            value={password}
+            onChangeText={setPassword}
+          />
+
+          <AppButton
+            title={busy ? 'Creando…' : 'Crear cuenta'}
+            onPress={onRegister}
+            disabled={busy}
+          />
+          <AppButton
+            title="¿Ya tienes cuenta? Inicia sesión"
+            variant="secondary"
+            onPress={() => navigation.replace('Login')}
+            style={{ marginTop: 10 }}
+          />
+        </View>
+      </View>
+    </KeyboardAvoidingView>
   );
 }
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 20 },
+  card: {
+    width: '100%',
+    maxWidth: 420,
+    backgroundColor: colors.card,
+    borderRadius: radius,
+    padding: 20,
+    gap: 12,
+  },
+  title: { fontSize: 22, fontWeight: '700', color: colors.text },
+  subtitle: { color: colors.muted, marginBottom: 4 },
+  input: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radius,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    fontSize: 16,
+    color: colors.text,
+    backgroundColor: '#fff',
+  },
+});

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,26 +1,48 @@
-import { auth } from './firebase';
+// src/services/auth.ts
+import { auth } from '../lib/firebase';
 import {
   signInWithEmailAndPassword,
   createUserWithEmailAndPassword,
   signOut,
   onAuthStateChanged,
-  User,
+  type User,
 } from 'firebase/auth';
 
-// Quita TODOS los espacios (incluye invisibles), normaliza y pasa a minúsculas
 const cleanEmail = (s: string) =>
-  s
-    .normalize('NFKC')   // normaliza caracteres raros
-    .replace(/\s/g, '')  // elimina cualquier whitespace (incluye espacios de ancho cero)
-    .toLowerCase();
+  s.normalize('NFKC').replace(/\s/g, '').toLowerCase();
 
-export const login = (email: string, password: string) =>
-  signInWithEmailAndPassword(auth, cleanEmail(email), password);
+export async function login(email: string, password: string) {
+  try {
+    const cred = await signInWithEmailAndPassword(auth, cleanEmail(email), password);
+    await cred.user.getIdToken(true);
+    return cred.user;
+  } catch (e: any) {
+    const code = e?.code || '';
+    if (
+      code.includes('wrong-password') ||
+      code.includes('invalid-credential') ||
+      code.includes('user-not-found')
+    ) {
+      // Aquí sí devolvemos un mensaje normalizado para Login
+      throw new Error('Credenciales inválidas');
+    }
+    throw new Error('No se pudo iniciar sesión');
+  }
+}
 
-export const register = (email: string, password: string) =>
-  createUserWithEmailAndPassword(auth, cleanEmail(email), password);
+export async function register(email: string, password: string): Promise<User> {
+  try {
+    const cred = await createUserWithEmailAndPassword(auth, cleanEmail(email), password);
+    await cred.user.getIdToken(true);
+    return cred.user;
+  } catch (e: any) {
+    // IMPORTANTE: no envolver el error; deja pasar el `code` de Firebase
+    if (e?.code) throw e;
+    const err = new Error('No se pudo crear la cuenta');
+    (err as any).code = 'unknown';
+    throw err;
+  }
+}
 
 export const logout = () => signOut(auth);
-
-export const listenAuth = (cb: (u: User | null) => void) =>
-  onAuthStateChanged(auth, cb);
+export const listenAuth = (cb: (u: User | null) => void) => onAuthStateChanged(auth, cb);

--- a/src/services/http.secure.ts
+++ b/src/services/http.secure.ts
@@ -1,0 +1,37 @@
+// src/services/http.secure.ts
+import axios, { AxiosHeaders, InternalAxiosRequestConfig } from 'axios';
+import { auth } from '../lib/firebase';
+import { signOut } from 'firebase/auth';
+
+export const httpSecure = axios.create({ timeout: 10000 });
+
+httpSecure.interceptors.request.use(async (config: InternalAxiosRequestConfig) => {
+  const user = auth.currentUser;
+  if (user) {
+    const token = await user.getIdToken();
+    const headers =
+      config.headers instanceof AxiosHeaders ? config.headers : new AxiosHeaders(config.headers);
+    headers.set('Authorization', `Bearer ${token}`);
+    config.headers = headers;
+    if (__DEV__) {
+      const val = headers.get('Authorization');
+      console.log('[httpSecure] Authorization:', val ? String(val).slice(0, 22) + '…' : 'none');
+    }
+  }
+  return config;
+});
+
+httpSecure.interceptors.response.use(
+  (res) => res,
+  async (error) => {
+    // 👇 algunos 401 cross-origin no exponen response.status; toma fallback del request
+    const s = Number(error?.response?.status ?? error?.request?.status ?? 0);
+    if (s === 401 || s === 403) {
+      console.warn('[httpSecure] 401/403 → signOut()');
+      try { await signOut(auth); } catch {}
+    } else {
+      console.warn('[httpSecure] error no-auth:', s || error?.message);
+    }
+    return Promise.reject(error);
+  }
+);

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,0 +1,25 @@
+import { Platform } from "react-native";
+
+export const colors = {
+    primary: "#1976D2",
+    primaryDark: "#115293",
+    danger: "#E53935",
+    bg: "#F6F8FA",
+    card: "#FFFFFF",
+    text: "#0F172A",
+    muted: "#64748B",
+    border: "#E2E8F0",
+};
+
+export const radius = 14;
+
+export const shadow = Platform.select({
+    ios: {
+        shadowColor: "#000",
+        shadowOffset: { width: 0, height: 3 },
+        shadowOpacity: 0.15,
+        shadowRadius: 6,
+    },
+    android: { elevation: 3 },
+    default: {}, // web
+});


### PR DESCRIPTION
## ¿Qué cambia?
- Añade cliente seguro `http.secure.ts`: inyecta `Authorization: Bearer <idToken>` y hace `signOut(auth)` ante 401/403.
- Separa navegación en stacks: App/Auth en `RootNavigator` con listener `onAuthStateChanged`.
- Refactor UI:
  - `LoginScreen`, `RegisterScreen`, `HomeScreen` con `theme.ts` y botón reutilizable `AppButton`.
  - `MapScreen` nativo (react-native-maps) y `MapScreen.web` placeholder (sin maps en web).

## Archivos principales
- `src/services/http.secure.ts`
- `src/services/auth.ts`
- `src/navigation/RootNavigator.tsx`
- `src/screens/{LoginScreen,RegisterScreen,HomeScreen,MapScreen.tsx,MapScreen.web.tsx}`
- `src/components/ui/AppButton.tsx`
- `src/theme.ts`
- `.env.example`

## QA / Cómo probar
1. Login con credenciales válidas → navega a Home.
2. (Opcional) Setear `EXPO_PUBLIC_SHOW_TEST_BUTTONS=1` y reiniciar:
   - “Probar envío de Authorization” → ver header Bearer en Network (httpbin).
   - “Probar 401” → interceptor ejecuta `signOut` y vuelve a Login.
3. Registro:
   - Email ya usado → mensaje “Ese correo ya está en uso”.
   - Contraseña < 6 → mensaje de validación.

## Checklist
- [x] Sin `.env` ni secretos en el repo
- [ ] **Tests unitarios** en próximo PR (rama `test/auth-cloud`)
